### PR TITLE
Support ef core versioning

### DIFF
--- a/shoppingcart-api/add-migration.ps1
+++ b/shoppingcart-api/add-migration.ps1
@@ -13,9 +13,14 @@ $repo = $config.repository.name
 $project = $config.database.dbContextProject
 $startup = $config.database.startupProject
 $context = $config.database.dbContext
+$efCoreVersion = $config.database.efCoreVersion
 
 echo "creating new migration $migration for $context context in project $project"
-dotnet tool update --global dotnet-ef
+if ($efCoreVersion) {
+	dotnet tool update --global dotnet-ef --version $efCoreVersion
+} else {
+	dotnet tool update --global dotnet-ef
+}
 
 dotnet ef migrations add $migration --project "$project" --startup-project "$startup" --context "$context"
 

--- a/shoppingcart-api/generate-sql.ps1
+++ b/shoppingcart-api/generate-sql.ps1
@@ -7,6 +7,7 @@ $repo = $config.repository.name
 $project = $config.database.dbContextProject
 $startup = $config.database.startupProject
 $context = $config.database.dbContext
+$efCoreVersion = $config.database.efCoreVersion
 
 echo "Generating transactional SQL migrations for $project..."
 
@@ -34,8 +35,11 @@ GO
 "@
 
 ## make sure dotnet ef is installed and up to date
-dotnet tool update --global dotnet-ef
-
+if ($efCoreVersion) {
+	dotnet tool update --global dotnet-ef --version $efCoreVersion
+} else {
+	dotnet tool update --global dotnet-ef
+}
 ## get list of migrations
 $migrations = (dotnet ef migrations list --no-build --project "$project" --startup-project "$startup" --context "$context")
 

--- a/shoppingcart-api/repository.json
+++ b/shoppingcart-api/repository.json
@@ -16,8 +16,7 @@
         "AuditLogTransaction",
         "Outbox"
       ]
-    },
-    "efCoreVersion": "9.0.11"
+    }
   },
   "docker": {
     "buildImage": "cortside/dotnet-sdk:8.0-alpine",

--- a/shoppingcart-api/repository.json
+++ b/shoppingcart-api/repository.json
@@ -16,7 +16,8 @@
         "AuditLogTransaction",
         "Outbox"
       ]
-    }
+    },
+    "efCoreVersion": "9.0.11"
   },
   "docker": {
     "buildImage": "cortside/dotnet-sdk:8.0-alpine",


### PR DESCRIPTION
We have an issue that the add-migration.ps1 and generate-sql.ps1 scripts attempt to install the latest version of dotnet ef core, but the latest version isn't yet available on artifactory (our nuget package soruce). This change allows us to specify the version in repository.json